### PR TITLE
Implemented static feature to support &'static Interned

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,11 @@ maintenance = { status = "passively-maintained" }
 
 [features]
 raw = ["hashbrown", "hashbrown/raw"]
+static = ["hashbrown"]
 
 [dependencies]
 parking_lot = { version = "0.12.1", optional = true, default-features = false }
 hashbrown = { version = "0.12.2", optional = true, default-features = false, features = ["raw"] }
+
+[dev-dependencies]
+hash32 = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ maintenance = { status = "passively-maintained" }
 
 [features]
 raw = ["hashbrown", "hashbrown/raw"]
-static = ["hashbrown"]
 
 [dependencies]
 parking_lot = { version = "0.12.1", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ static = ["hashbrown"]
 
 [dependencies]
 parking_lot = { version = "0.12.1", optional = true, default-features = false }
-hashbrown = { version = "0.12.2", optional = true, default-features = false, features = ["raw"] }
+hashbrown = { version = "0.12.2", optional = true, default-features = false }
 
 [dev-dependencies]
 hash32 = "0.3"

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -170,8 +170,8 @@ impl<T: Eq + Hash + ?Sized, S: BuildHasher> Interner<T, S> {
         // but needs a different call than intern_raw to use the intrinsic
         // BuildHasher rather than an external one. It's not worth the effort.
 
-        let boxed = PinBox::new(t.into());
-        match arena.entry(boxed) {
+        let entry = arena.entry(PinBox::new(t.into()));
+        match entry {
             Entry::Occupied(entry) => Interned(unsafe { entry.key().as_ref() }),
             Entry::Vacant(entry) => {
                 let interned = Interned(unsafe { entry.key().as_ref() });
@@ -269,7 +269,7 @@ impl<T: ?Sized> Interner<T> {
 
 /// Constructors to control the backing `HashSet`'s hash function
 impl<T: Eq + Hash + ?Sized, H: BuildHasher> Interner<T, H> {
-    #[cfg(not(feature = "static"))]
+    #[cfg(not(feature = "hashbrown"))]
     /// Create an empty interner which will use the given hasher to hash the values.
     ///
     /// The interner is also created with the default capacity.
@@ -279,7 +279,7 @@ impl<T: Eq + Hash + ?Sized, H: BuildHasher> Interner<T, H> {
         }
     }
 
-    #[cfg(feature = "static")]
+    #[cfg(feature = "hashbrown")]
     /// Create an empty interner which will use the given hasher to hash the values.
     ///
     /// The interner is also created with the default capacity.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,26 +13,28 @@
 //! This crate exists to give the option of using the simplest interface. For
 //! a more featureful interner, consider using a different crate, such as
 //!
-//! |             crate | non-global | `'static` opt | non-`str` |  symbol size  | symbols deref
-//! | ----------------: | :--------: | :-----------: | :-------: | :-----------: | :-----------:
-//! |   simple-interner |    yes     |      yes[^1]  |    yes    |     `&T`      |      yes
-//! |        [intaglio] |    yes     |      yes      |    no     |     `u32`     |      no
-//! |      [internment] | optionally |      no       |    yes    |     `&T`      |      yes
-//! |           [lasso] |    yes     |      yes      |    no     | `u8`–`usize`  |      no
-//! | [string-interner] |    yes     |  optionally   |    no     | `u16`–`usize` |      no
-//! |    [string_cache] |    yes     |  buildscript  |    no     |     `u64`     |      yes
-//! |    [symbol_table] | optionally |      no       |    no     |     `u32`     |  global only
-//! |            [ustr] |    no      |      no       |    no     |    `usize`    |      yes
+//! |             crate |    global   | local | `'static` opt [^1] | non-`str` |  symbol size  | symbols deref
+//! | ----------------: | :---------: | :---: | :----------------: | :-------: | :-----------: | :-----------:
+//! |   simple-interner |     yes     |  yes  |         no         |    yes    |     `&T`      |      yes
+//! |        [intaglio] |     no      |  yes  |         yes        |    no     |     `u32`     |      no
+//! |      [internment] |     yes     |  yes  |         no         |    yes    |     `&T`      |      yes
+//! |           [lasso] |     no      |  yes  |         yes        |    no     | `u8`–`usize`  |      no
+//! | [string-interner] |     no      |  yes  |     optionally     |    no     | `u16`–`usize` |      no
+//! |    [string_cache] | buildscript |  yes  |     buildscript    |    no     |     `u64`     |      yes
+//! |    [symbol_table] |     yes     |  yes  |         no         |    no     |     `u32`     |  global only
+//! |            [ustr] |     yes     |  no   |         no         |    no     |    `usize`    |      yes
 //!
 //! (PRs to this table are welcome!) <!-- crate must have seen activity in the last year -->
 //!
-//! [^1]: Available with the `static` feature and [`Interner::with_hasher`].
+//! [^1]: The `'static` optimization refers to storing `&'static` references
+//!       without copying the pointee into the backing store, e.g. storing
+//!       `Cow<'static, str>` instead of `Box<str>`.
 //!
 //! [intaglio]: https://lib.rs/crates/intaglio
 //! [lasso]: https://lib.rs/crates/lasso
 //! [internment]: https://lib.rs/crates/internment
 //! [string-interner]: https://lib.rs/crates/string-interner
-//! [string_cache]: https://lib.rs/crates/string-cache
+//! [string_cache]: https://lib.rs/crates/string_cache
 //! [symbol_table]: https://lib.rs/crates/symbol_table
 //! [ustr]: https://lib.rs/crates/ustr
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! |             crate |    global   | local | `'static` opt [^1] | non-`str` |  symbol size  | symbols deref
 //! | ----------------: | :---------: | :---: | :----------------: | :-------: | :-----------: | :-----------:
-//! |   simple-interner |     yes     |  yes  |         no         |    yes    |     `&T`      |      yes
+//! |   simple-interner |   yes [^2]  |  yes  |         no         |    yes    |     `&T`      |      yes
 //! |        [intaglio] |     no      |  yes  |         yes        |    no     |     `u32`     |      no
 //! |      [internment] |     yes     |  yes  |         no         |    yes    |     `&T`      |      yes
 //! |           [lasso] |     no      |  yes  |         yes        |    no     | `u8`–`usize`  |      no
@@ -29,6 +29,10 @@
 //! [^1]: The `'static` optimization refers to storing `&'static` references
 //!       without copying the pointee into the backing store, e.g. storing
 //!       `Cow<'static, str>` instead of `Box<str>`.
+//!
+//! [^2]: At the moment, creating the [`Interner`] inside a `static`, using
+//!       [`Interner::with_hasher`], requires the `hashbrown` feature to
+//!       be enabled.
 //!
 //! [intaglio]: https://lib.rs/crates/intaglio
 //! [lasso]: https://lib.rs/crates/lasso
@@ -115,7 +119,7 @@ mod tests {
         assert_eq!(d2.as_ptr(), d3.as_ptr());
     }
 
-    #[cfg(feature = "static")]
+    #[cfg(feature = "hashbrown")]
     #[test]
     fn static_interner() {
         use hash32::{BuildHasherDefault, FnvHasher};


### PR DESCRIPTION
This PR would allow the `Interner` to be used in a `static`. Since `std::sync::RwLock` will only support const construction in 1.63 (`parking_lot` already supports it), and `HashMap::with_hasher` is only const in `hashbrown` so far, I've added a `static` feature for users to explicitly opt into making the `Interner::with_hasher` constructor const. Perhaps, this could also be done with build-script feature detection instead.

Apart from constifying the `Interner::with_hasher` method, I also had to make `PinBox<T>` `Send` and `Sync` if `T` is, respectively. I definitely need some help with the explanation of why this holds.

Lastly, I was looking for a `BuildHasher` that allows const construction, and the one `hash32` provides is the first one I found. To not add it as a dev-dependency, we could also add a simple dummy hasher for this test case.