### PR TITLE
Implement `no_std` support with `hashbrown`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,9 @@ jobs:
         with:
           command: hack
           args: test --feature-powerset --optional-deps --exclude-all-features --keep-going
+        env:
+          RUSTFLAGS: --cfg=ci_powerset
+          RUSTDOCFLAGS: --cfg=ci_powerset
 
   miri:
     name: Test feature powerset under miri
@@ -115,3 +118,6 @@ jobs:
         with:
           command: hack
           args: miri test --feature-powerset --optional-deps
+        env:
+          RUSTFLAGS: --cfg=ci_powerset
+          RUSTDOCFLAGS: --cfg=ci_powerset

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,13 @@ license = "Apache-2.0 OR MIT"
 maintenance = { status = "passively-maintained" }
 
 [features]
+default = ["std"]
+std = []
 raw = ["hashbrown", "hashbrown/raw"]
 
 [dependencies]
 parking_lot = { version = "0.12.1", optional = true, default-features = false }
-hashbrown = { version = "0.12.2", optional = true, default-features = false }
+hashbrown = { version = "0.13.2", optional = true, default-features = false, features = ["ahash"] }
 
 [dev-dependencies]
 hash32 = "0.3.1"

--- a/src/interned.rs
+++ b/src/interned.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Borrow, ops::Deref, ptr};
+use core::{borrow::Borrow, ops::Deref, ptr};
 
 /// An item interned by an `Interner`.
 ///

--- a/src/interner.rs
+++ b/src/interner.rs
@@ -1,8 +1,8 @@
 use {
     crate::Interned,
-    std::{
+    core::{
         borrow::Borrow,
-        collections::hash_map::RandomState,
+        cmp::Ordering,
         fmt,
         hash::{BuildHasher, Hash, Hasher},
         marker::PhantomData,
@@ -11,10 +11,17 @@ use {
     },
 };
 
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
+#[cfg(all(not(feature = "std"), feature = "hashbrown"))]
+use hashbrown::hash_map::DefaultHashBuilder as RandomState;
 #[cfg(feature = "raw")]
 use hashbrown::hash_map::RawEntryMut;
 #[cfg(feature = "hashbrown")]
 use hashbrown::hash_map::{Entry, HashMap};
+#[cfg(feature = "std")]
+use std::collections::hash_map::RandomState;
 #[cfg(not(feature = "hashbrown"))]
 use std::collections::hash_map::{Entry, HashMap};
 
@@ -82,17 +89,17 @@ impl<T: ?Sized + PartialEq> PartialEq<T> for PinBox<T> {
 }
 
 impl<T: ?Sized + Ord> Ord for PinBox<T> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> Ordering {
         (**self).cmp(&**other)
     }
 }
 impl<T: ?Sized + PartialOrd> PartialOrd for PinBox<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         (**self).partial_cmp(&**other)
     }
 }
 impl<T: ?Sized + PartialOrd> PartialOrd<T> for PinBox<T> {
-    fn partial_cmp(&self, other: &T) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &T) -> Option<Ordering> {
         (**self).partial_cmp(other)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,18 +45,37 @@
 
 #![forbid(unconditional_recursion, future_incompatible)]
 #![warn(unsafe_code, bad_style, missing_docs, missing_debug_implementations)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(all(
+    not(feature = "std"),
+    any(not(feature = "hashbrown"), not(feature = "parking_lot")),
+    not(ci_powerset)
+))]
+compile_error!("no-std requires enabling both the `hashbrown` and `parking_lot` features");
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 #[cfg(feature = "parking_lot")]
 mod parking_lot_shim;
 
+#[cfg(any(feature = "std", all(feature = "hashbrown", feature = "parking_lot")))]
 mod interner;
+#[cfg(any(feature = "std", all(feature = "hashbrown", feature = "parking_lot")))]
 pub use interner::Interner;
 
+#[cfg(any(feature = "std", all(feature = "hashbrown", feature = "parking_lot")))]
 mod interned;
+#[cfg(any(feature = "std", all(feature = "hashbrown", feature = "parking_lot")))]
 pub use interned::Interned;
 
 #[cfg(test)]
+#[cfg(any(feature = "std", all(feature = "hashbrown", feature = "parking_lot")))]
 mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::{boxed::Box, string::String, vec::Vec};
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
I am hoping to use `simple-interner` in a `no_std` context and wanted to see if it is possible to support that. Here's the changes I had to make - hopefully this could be simplified?
- small import redirections
- new `std` feature that is enabled by default
- `compile_error` if `std` is disabled and `hashbrown` ~~and `parking_lot`~~ are not both enabled
- enable the `hashbrown/ahash` feature for a functioning default hasher
- disable the `compile_error` when running the powerset tests in CI